### PR TITLE
Only query Chronicle during RemoteFetch.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,6 +25,8 @@
   ],
   "require": {
     "php": "^5.5|^7",
+    "ext-curl": "*",
+    "ext-json": "*",
     "guzzlehttp/guzzle": "^6",
     "paragonie/constant_time_encoding": "^1|^2",
     "paragonie/sodium_compat": "^1.11"

--- a/src/Fetch.php
+++ b/src/Fetch.php
@@ -163,11 +163,13 @@ class Fetch
     /**
      * @param int $index
      * @param string $reason
+     * @return void
      * @throws EncodingException
      * @throws FilesystemException
      */
     protected function markBundleAsBad($index = 0, $reason = '')
     {
+        /** @var array<int, array<string, string>> $data */
         $data = $this->loadCaCertsFile();
         $now = (new \DateTime())->format(\DateTime::ATOM);
         $data[$index]['bad-bundle'] = 'Marked bad on ' . $now . ' for reason: ' . $reason;

--- a/src/RemoteFetch.php
+++ b/src/RemoteFetch.php
@@ -185,6 +185,7 @@ class RemoteFetch extends Fetch
                 /** @var string $body */
                 $body = (string) $request->getBody();
                 \file_put_contents($this->dataDirectory . '/' . $filename, $body);
+                $this->unverified []= $this->dataDirectory . '/' . $item['file'];
             }
         }
 

--- a/test/RemoteFetchTest.php
+++ b/test/RemoteFetchTest.php
@@ -58,5 +58,13 @@ class RemoteFetchTest extends TestCase
         );
         $fetch->setCacheTimeout(new \DateInterval('PT01M'));
         $this->assertTrue($fetch->cacheExpired());
+
+
+        $latest = $fetch->getLatestBundle();
+        file_put_contents($latest->getFilePath(), ' corrupt', FILE_APPEND);
+        (new RemoteFetch($this->dir))->getLatestBundle();
+
+        $cacerts = json_decode(file_get_contents($this->dir . '/ca-certs.json'), true);
+        $this->assertTrue(!empty($cacerts[0]['bad-bundle']));
     }
 }


### PR DESCRIPTION
This prevents users from wasting bandwidth.