### PR TITLE
Allow using Guzzle v7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "^5.5|^7|^8",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6",
+    "guzzlehttp/guzzle": "^6|^7",
     "paragonie/constant_time_encoding": "^1|^2",
     "paragonie/sodium_compat": "^1.11"
   },


### PR DESCRIPTION
I need to be able to use certainty with Guzzle 7 as one of the dependencies on a project requires Guzzle 7.  This pull request allows installing either Guzzle 6 or Guzzle 7.  Tested with Guzzle 7.