### PR TITLE
Allow installation on laravel 8 by allowing Guzzle 7 too

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "php": "^5.5|^7|^8",
     "ext-curl": "*",
     "ext-json": "*",
-    "guzzlehttp/guzzle": "^6",
+    "guzzlehttp/guzzle": "^6.0|^7.0",
     "paragonie/constant_time_encoding": "^1|^2",
     "paragonie/sodium_compat": "^1.11"
   },


### PR DESCRIPTION
Some laravel packages uses this. But can't upgrade to laravel 8 as laravel 8 requires guzzle 7.

This PR allow both guzzle 6 and guzzle 7 in composer.json